### PR TITLE
Add entries count to StreamStarted event

### DIFF
--- a/lib/packmatic/encoder/event.ex
+++ b/lib/packmatic/encoder/event.ex
@@ -12,7 +12,8 @@ defmodule Packmatic.Encoder.Event do
   def emit_stream_started(state) do
     emit(state, fn ->
       %StreamStarted{
-        stream_id: state.stream_id
+        stream_id: state.stream_id,
+        entries_count: length(state.remaining)
       }
     end)
   end

--- a/lib/packmatic/event.ex
+++ b/lib/packmatic/event.ex
@@ -64,18 +64,19 @@ defmodule Packmatic.Event do
     """
 
     @type t :: %__MODULE__{
-            stream_id: Encoder.stream_id()
+            stream_id: Encoder.stream_id(),
+            entries_count: non_neg_integer()
           }
 
-    @enforce_keys ~w(stream_id)a
-    defstruct stream_id: nil
+    @enforce_keys ~w(stream_id entries_count)a
+    defstruct stream_id: nil, entries_count: 0
   end
 
   defmodule StreamEnded do
     @moduledoc """
     Represents an Event that is raised when the Encoder completes work. In case of normal
     completion, the reason will be set to `:done`, otherwise and in case of Source errors, the
-    reason will be carried across. 
+    reason will be carried across.
     """
 
     @type t :: %__MODULE__{


### PR DESCRIPTION
Add original entries count to the StreamStarted event to be able calculate progress in `on_event` callbacks.