### PR TITLE
Add ability to set archive_id to build_stream

### DIFF
--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -44,8 +44,10 @@ defmodule Packmatic.Encoder do
     
   - `on_event` can be set to a function which will be called when events are raised by the Encoder
     during its lifecycle. See `Packmatic.Event` for further information.
+
+  - `archive_id` can be set to be used as a stream_id in `on_event` callbacks.
   """
-  @type option :: {:on_error, :skip | :halt} | {:on_event, Event.handler_fun()}
+  @type option :: {:on_error, :skip | :halt} | {:on_event, Event.handler_fun()} | {:archive_id, integer()}
 
   @typedoc """
   Represents an unique identifier of the Stream in operation. This allows you to distinguish

--- a/lib/packmatic/encoder/encoding.ex
+++ b/lib/packmatic/encoder/encoding.ex
@@ -25,7 +25,7 @@ defmodule Packmatic.Encoder.Encoding do
           | {:halt, {:error, term()}}
 
   def encoding_start(%Manifest{valid?: true} = manifest, options) do
-    id = make_ref()
+    id = Keyword.get(options, :archive_id) || make_ref()
     entries = manifest.entries
     on_error = Keyword.get(options, :on_error, :halt)
     on_event = Keyword.get(options, :on_event)


### PR DESCRIPTION
Add `archive_id` option to `Pacmatic.build_stream` in order to have known `stream_id` value in event callbacks.